### PR TITLE
fix: current account tixed to return bech32 address

### DIFF
--- a/.changeset/angry-needles-kiss.md
+++ b/.changeset/angry-needles-kiss.md
@@ -1,0 +1,5 @@
+---
+"@fuel-connectors/walletconnect-connector": patch
+---
+
+Fix currentAccount to return a Bech32 address

--- a/packages/walletconnect-connector/src/WalletConnectConnector.ts
+++ b/packages/walletconnect-connector/src/WalletConnectConnector.ts
@@ -272,7 +272,9 @@ export class WalletConnectConnector extends FuelConnector {
     if (!(await this.isConnected())) {
       throw Error('No connected accounts');
     }
-    return getAccount(this.wagmiConfig).address || null;
+    const ethAccount = getAccount(this.wagmiConfig).address || null;
+
+    return this.predicateAccount.getPredicateAddress(ethAccount as string);
   }
 
   async addAssets(_assets: Asset[]): Promise<boolean> {


### PR DESCRIPTION
**Problem:**
- Current account method of Wallet Connect Connector was returning a B256 address instead of Bech32.

**Fix:**
- Changed to return Bech32 address in currentAccount Method